### PR TITLE
Sample/diva sdk v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## 下载
 
 ```shell
-git clone https://github.com/sheencity/diva-sample-angular
+git clone https://github.com/sheencity/diva-sample-angular.git
 ```
 
 ## 安装依赖

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">DIVA Sample</h1>
+<h1 align="center">DIVA Sample Angular</h1>
 <div align="center">
   <strong>Digital Intelligence Visualization API</strong>
 </div>
@@ -9,7 +9,7 @@
 ## 下载
 
 ```shell
-git clone https://github.com/sheencity/diva-sample
+git clone https://github.com/sheencity/diva-sample-angular
 ```
 
 ## 安装依赖

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@angular-devkit/build-angular": "~12.0.1",
         "@angular/cli": "~12.0.1",
         "@angular/compiler-cli": "~12.0.1",
-        "@sheencity/diva-sdk": "^0.1.1",
+        "@sheencity/diva-sdk": "^0.2.0-alpha.1",
         "@types/jasmine": "~3.6.0",
         "@types/node": "^12.11.1",
         "tslint": "~6.1.0",
@@ -2309,31 +2309,52 @@
       }
     },
     "node_modules/@sheencity/diva-sdk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk/-/diva-sdk-0.1.1.tgz",
-      "integrity": "sha512-3AnXkUh6Q2WLZlcSTAbUQ5x9qKxodLIkH7J+DfliedC5v5Z26qIvyGX8thYoRa7j5oZOGa7H+AXsnb1ZaS+rXw==",
+      "version": "0.2.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk/-/diva-sdk-0.2.0-alpha.10.tgz",
+      "integrity": "sha512-4nC/CaREWU1VwYnQzq2O8FAEm/IkuG/VDRe/MM21pQn+sUNMBix24M5vUd0Fjv2CffPfvKY5YdgRJ5DH88g61g==",
       "bundleDependencies": [
         "tslib",
         "jsonrpc-lite"
       ],
       "dev": true,
       "dependencies": {
-        "@sheencity/diva-sdk-math": "~0.1.0",
         "jsonrpc-lite": "*",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14.15.0",
+        "npm": ">=7.1.0"
       },
       "peerDependencies": {
+        "@sheencity/diva-sdk-adapter": "0.2.0-alpha.3",
+        "@sheencity/diva-sdk-math": "0.2.0-alpha.10",
         "jsonrpc-lite": "^2.2.0",
-        "socket.io-client": "^4.0.0"
+        "reflect-metadata": "^0.1.13",
+        "rxjs": "^6.6.7",
+        "socket.io-client": "^4.1.3"
+      }
+    },
+    "node_modules/@sheencity/diva-sdk-adapter": {
+      "version": "0.2.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-adapter/-/diva-sdk-adapter-0.2.0-alpha.3.tgz",
+      "integrity": "sha512-14QmvnfwFbFB/99WDvYQle8z8qrwXJ87h03ZxF4rajO9l9O0LFNZHD2DQsTLmHuG8QhyZnXUf9Qrpp8xhkqvLw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^6.6.7"
       }
     },
     "node_modules/@sheencity/diva-sdk-math": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-math/-/diva-sdk-math-0.1.0.tgz",
-      "integrity": "sha512-LunReBq13tidM0Tyseb/dKw5TTToj0kSAZIQirPMj+RlHhmxbS3BUQflOIWpSZLr/cek87XtPUB/Wq29w5V5sA==",
+      "version": "0.2.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-math/-/diva-sdk-math-0.2.0-alpha.10.tgz",
+      "integrity": "sha512-2ZzfLaplY1QpU6b0PSeOSQDlsfU8WCBYdlTy2gD8wNz611lVWvgkyg0Slu8Hk9cpk8B3xNE+VwApLP2WVb/tjA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -13207,15 +13228,15 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.1.2.tgz",
-      "integrity": "sha512-RDpWJP4DQT1XeexmeDyDkm0vrFc0+bUsHDKiVGaNISJvJonhQQOMqV9Vwfg0ZpPJ27LCdan7iqTI92FRSOkFWQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.1.3.tgz",
+      "integrity": "sha512-hISFn6PDpgDifVUiNklLHVPTMv1LAk8poHArfIUdXa+gKgbr0MZbAlquDFqCqsF30yBqa+jg42wgos2FK50BHA==",
       "dependencies": {
         "@types/component-emitter": "^1.2.10",
         "backo2": "~1.0.2",
         "component-emitter": "~1.3.0",
         "debug": "~4.3.1",
-        "engine.io-client": "~5.1.1",
+        "engine.io-client": "~5.1.2",
         "parseuri": "0.0.6",
         "socket.io-parser": "~4.0.4"
       },
@@ -17474,23 +17495,33 @@
       }
     },
     "@sheencity/diva-sdk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk/-/diva-sdk-0.1.1.tgz",
-      "integrity": "sha512-3AnXkUh6Q2WLZlcSTAbUQ5x9qKxodLIkH7J+DfliedC5v5Z26qIvyGX8thYoRa7j5oZOGa7H+AXsnb1ZaS+rXw==",
+      "version": "0.2.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk/-/diva-sdk-0.2.0-alpha.10.tgz",
+      "integrity": "sha512-4nC/CaREWU1VwYnQzq2O8FAEm/IkuG/VDRe/MM21pQn+sUNMBix24M5vUd0Fjv2CffPfvKY5YdgRJ5DH88g61g==",
       "dev": true,
       "requires": {
-        "@sheencity/diva-sdk-math": "~0.1.0",
         "jsonrpc-lite": "*",
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.0"
+      }
+    },
+    "@sheencity/diva-sdk-adapter": {
+      "version": "0.2.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-adapter/-/diva-sdk-adapter-0.2.0-alpha.3.tgz",
+      "integrity": "sha512-14QmvnfwFbFB/99WDvYQle8z8qrwXJ87h03ZxF4rajO9l9O0LFNZHD2DQsTLmHuG8QhyZnXUf9Qrpp8xhkqvLw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "tslib": "^2.3.0"
       }
     },
     "@sheencity/diva-sdk-math": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-math/-/diva-sdk-math-0.1.0.tgz",
-      "integrity": "sha512-LunReBq13tidM0Tyseb/dKw5TTToj0kSAZIQirPMj+RlHhmxbS3BUQflOIWpSZLr/cek87XtPUB/Wq29w5V5sA==",
+      "version": "0.2.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-math/-/diva-sdk-math-0.2.0-alpha.10.tgz",
+      "integrity": "sha512-2ZzfLaplY1QpU6b0PSeOSQDlsfU8WCBYdlTy2gD8wNz611lVWvgkyg0Slu8Hk9cpk8B3xNE+VwApLP2WVb/tjA==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.0"
       }
     },
     "@tootallnate/once": {
@@ -25845,15 +25876,15 @@
       }
     },
     "socket.io-client": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.1.2.tgz",
-      "integrity": "sha512-RDpWJP4DQT1XeexmeDyDkm0vrFc0+bUsHDKiVGaNISJvJonhQQOMqV9Vwfg0ZpPJ27LCdan7iqTI92FRSOkFWQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.1.3.tgz",
+      "integrity": "sha512-hISFn6PDpgDifVUiNklLHVPTMv1LAk8poHArfIUdXa+gKgbr0MZbAlquDFqCqsF30yBqa+jg42wgos2FK50BHA==",
       "requires": {
         "@types/component-emitter": "^1.2.10",
         "backo2": "~1.0.2",
         "component-emitter": "~1.3.0",
         "debug": "~4.3.1",
-        "engine.io-client": "~5.1.1",
+        "engine.io-client": "~5.1.2",
         "parseuri": "0.0.6",
         "socket.io-parser": "~4.0.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@angular-devkit/build-angular": "~12.0.1",
         "@angular/cli": "~12.0.1",
         "@angular/compiler-cli": "~12.0.1",
-        "@sheencity/diva-sdk": "^0.2.0-alpha.10",
+        "@sheencity/diva-sdk": "^0.2.1",
         "@types/jasmine": "~3.6.0",
         "@types/node": "^12.11.1",
         "tslint": "~6.1.0",
@@ -2309,9 +2309,9 @@
       }
     },
     "node_modules/@sheencity/diva-sdk": {
-      "version": "0.2.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk/-/diva-sdk-0.2.0-alpha.10.tgz",
-      "integrity": "sha512-4nC/CaREWU1VwYnQzq2O8FAEm/IkuG/VDRe/MM21pQn+sUNMBix24M5vUd0Fjv2CffPfvKY5YdgRJ5DH88g61g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk/-/diva-sdk-0.2.1.tgz",
+      "integrity": "sha512-/AhIaQNqcI9cmtX2M3Jgg9GV2a2/KoO8MtajLeOeCSwIk+HCcoPDSg2fTcXk/6wkBwPD8BX1XhfvlScXMwV33g==",
       "bundleDependencies": [
         "tslib",
         "jsonrpc-lite"
@@ -2326,8 +2326,8 @@
         "npm": ">=7.1.0"
       },
       "peerDependencies": {
-        "@sheencity/diva-sdk-adapter": "0.2.0-alpha.3",
-        "@sheencity/diva-sdk-math": "0.2.0-alpha.10",
+        "@sheencity/diva-sdk-adapter": "0.2.1",
+        "@sheencity/diva-sdk-math": "0.2.1",
         "jsonrpc-lite": "^2.2.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^6.6.7",
@@ -2335,9 +2335,9 @@
       }
     },
     "node_modules/@sheencity/diva-sdk-adapter": {
-      "version": "0.2.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-adapter/-/diva-sdk-adapter-0.2.0-alpha.3.tgz",
-      "integrity": "sha512-14QmvnfwFbFB/99WDvYQle8z8qrwXJ87h03ZxF4rajO9l9O0LFNZHD2DQsTLmHuG8QhyZnXUf9Qrpp8xhkqvLw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-adapter/-/diva-sdk-adapter-0.2.1.tgz",
+      "integrity": "sha512-axdcP3kn2r6VHJJU8cvw9/M6DG/cIG+epRZNZEhjB5rSyg6UqQv83NLRC+NjJwShyKqNb5urAiG8L7eZ2ZQjuw==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/@sheencity/diva-sdk-math": {
-      "version": "0.2.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-math/-/diva-sdk-math-0.2.0-alpha.10.tgz",
-      "integrity": "sha512-2ZzfLaplY1QpU6b0PSeOSQDlsfU8WCBYdlTy2gD8wNz611lVWvgkyg0Slu8Hk9cpk8B3xNE+VwApLP2WVb/tjA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-math/-/diva-sdk-math-0.2.1.tgz",
+      "integrity": "sha512-weRWdyM6dULCYFwNyvKt97eh/Jvk2tAEpvdWrWKyL/PEQL/zaFR3LwWZsOW3pnXChbyTneWKpYS8d5Wmypxf7w==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -17495,9 +17495,9 @@
       }
     },
     "@sheencity/diva-sdk": {
-      "version": "0.2.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk/-/diva-sdk-0.2.0-alpha.10.tgz",
-      "integrity": "sha512-4nC/CaREWU1VwYnQzq2O8FAEm/IkuG/VDRe/MM21pQn+sUNMBix24M5vUd0Fjv2CffPfvKY5YdgRJ5DH88g61g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk/-/diva-sdk-0.2.1.tgz",
+      "integrity": "sha512-/AhIaQNqcI9cmtX2M3Jgg9GV2a2/KoO8MtajLeOeCSwIk+HCcoPDSg2fTcXk/6wkBwPD8BX1XhfvlScXMwV33g==",
       "dev": true,
       "requires": {
         "jsonrpc-lite": "*",
@@ -17505,9 +17505,9 @@
       }
     },
     "@sheencity/diva-sdk-adapter": {
-      "version": "0.2.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-adapter/-/diva-sdk-adapter-0.2.0-alpha.3.tgz",
-      "integrity": "sha512-14QmvnfwFbFB/99WDvYQle8z8qrwXJ87h03ZxF4rajO9l9O0LFNZHD2DQsTLmHuG8QhyZnXUf9Qrpp8xhkqvLw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-adapter/-/diva-sdk-adapter-0.2.1.tgz",
+      "integrity": "sha512-axdcP3kn2r6VHJJU8cvw9/M6DG/cIG+epRZNZEhjB5rSyg6UqQv83NLRC+NjJwShyKqNb5urAiG8L7eZ2ZQjuw==",
       "dev": true,
       "peer": true,
       "requires": {
@@ -17515,9 +17515,9 @@
       }
     },
     "@sheencity/diva-sdk-math": {
-      "version": "0.2.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-math/-/diva-sdk-math-0.2.0-alpha.10.tgz",
-      "integrity": "sha512-2ZzfLaplY1QpU6b0PSeOSQDlsfU8WCBYdlTy2gD8wNz611lVWvgkyg0Slu8Hk9cpk8B3xNE+VwApLP2WVb/tjA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sheencity/diva-sdk-math/-/diva-sdk-math-0.2.1.tgz",
+      "integrity": "sha512-weRWdyM6dULCYFwNyvKt97eh/Jvk2tAEpvdWrWKyL/PEQL/zaFR3LwWZsOW3pnXChbyTneWKpYS8d5Wmypxf7w==",
       "dev": true,
       "peer": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@angular-devkit/build-angular": "~12.0.1",
         "@angular/cli": "~12.0.1",
         "@angular/compiler-cli": "~12.0.1",
-        "@sheencity/diva-sdk": "^0.2.0-alpha.1",
+        "@sheencity/diva-sdk": "^0.2.0-alpha.10",
         "@types/jasmine": "~3.6.0",
         "@types/node": "^12.11.1",
         "tslint": "~6.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@angular-devkit/build-angular": "~12.0.1",
     "@angular/cli": "~12.0.1",
     "@angular/compiler-cli": "~12.0.1",
-    "@sheencity/diva-sdk": "^0.2.0-alpha.10",
+    "@sheencity/diva-sdk": "^0.2.1",
     "@types/jasmine": "~3.6.0",
     "@types/node": "^12.11.1",
     "tslint": "~6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "diva-sdk",
+  "name": "diva-sample-angular",
   "version": "0.0.0",
-  "repository": "https://github.com/sheencity/diva-sample",
+  "repository": "https://github.com/sheencity/diva-sample-angular",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@angular-devkit/build-angular": "~12.0.1",
     "@angular/cli": "~12.0.1",
     "@angular/compiler-cli": "~12.0.1",
-    "@sheencity/diva-sdk": "^0.1.1",
+    "@sheencity/diva-sdk": "^0.2.0-alpha.1",
     "@types/jasmine": "~3.6.0",
     "@types/node": "^12.11.1",
     "tslint": "~6.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@angular-devkit/build-angular": "~12.0.1",
     "@angular/cli": "~12.0.1",
     "@angular/compiler-cli": "~12.0.1",
-    "@sheencity/diva-sdk": "^0.2.0-alpha.1",
+    "@sheencity/diva-sdk": "^0.2.0-alpha.10",
     "@types/jasmine": "~3.6.0",
     "@types/node": "^12.11.1",
     "tslint": "~6.1.0",

--- a/src/app/common/models/overlay.model.ts
+++ b/src/app/common/models/overlay.model.ts
@@ -1,3 +1,4 @@
+import { POIIcon } from '@sheencity/diva-sdk';
 import { v4 } from 'uuid';
 export enum OverlayType {
   POI = 'poi',
@@ -5,21 +6,10 @@ export enum OverlayType {
   Emissive = 'emissiveOverlay',
 }
 
-export enum POIIcon {
-  Camera = 'camera',
-  Location = 'location',
-  TrafficLight = 'trafficLight',
-  TrashCan = 'trashCan',
-  StreetLamp = 'streetLamp',
-  BusStation = 'busStation',
-  Exit = 'exit',
-  Restaurant = 'restaurant',
-  Parking = 'parking',
-  Dock = 'dock',
-  Subway = 'subway',
-  Supermarket = 'supermarket',
-  Mall = 'mall',
-  Toilet = 'toilet',
+export enum POIType {
+  type1 = 'POI文字标签',
+  type2 = 'POI圆形标签',
+  type3 = 'POI水滴',
 }
 
 export enum EmissionType {
@@ -53,6 +43,7 @@ export class Overlay {
 export class POIOverlay extends Overlay {
   public readonly type = OverlayType.POI;
   public icon: POIIcon;
+  public iconType: POIType;
 }
 
 export class MarkerOverlay extends Overlay {

--- a/src/app/common/services/diva.service.ts
+++ b/src/app/common/services/diva.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Diva, DivaClient } from '@sheencity/diva-sdk';
+import { Diva, DivaClient, WebRtcAdapter } from '@sheencity/diva-sdk';
 
 @Injectable({
   providedIn: 'root',
@@ -19,7 +19,8 @@ export class DivaService {
     const uri = 'http://127.0.0.1:3000';
     const apiKey = '<replace_your_api_key_here>';
     console.log(uri, apiKey, container);
-    const diva = new Diva({ container, apiKey, uri });
+    const adapter = new WebRtcAdapter(container, uri);
+    const diva = new Diva({ apiKey, adapter });
     console.log('diva is', diva);
     this.client = await diva.init();
     console.log('client is', this.client);

--- a/src/app/pages/overlay/overlay.component.html
+++ b/src/app/pages/overlay/overlay.component.html
@@ -53,13 +53,13 @@
         </div>
       </div>
       <div class="drop-item" style="margin-top: 12px;" *ngIf="selectedType.value === 'poi' && selectedIconType.value !== 'POI水滴'">
-        <span>Icon</span>
+        <span>图标</span>
         <div>
           <app-dropdown [options]="iconOptions1" [(ngModel)]="selectedIcon"></app-dropdown>
         </div>
       </div>
       <div class="drop-item" style="margin-top: 12px;" *ngIf="selectedType.value === 'poi' && selectedIconType.value === 'POI水滴'">
-        <span>Icon</span>
+        <span>图标</span>
         <div>
           <app-dropdown [options]="iconOptions2" [(ngModel)]="selectedIcon"></app-dropdown>
         </div>

--- a/src/app/pages/overlay/overlay.component.html
+++ b/src/app/pages/overlay/overlay.component.html
@@ -49,7 +49,19 @@
       <div class="drop-item" style="margin-top: 12px;" *ngIf="selectedType.value === 'poi'">
         <span>类型</span>
         <div>
-          <app-dropdown [options]="iconOptions" [(ngModel)]="selectedIcon"></app-dropdown>
+          <app-dropdown (select)="resetPoiIcon($event)" [options]="iconTypeOption" [(ngModel)]="selectedIconType"></app-dropdown>
+        </div>
+      </div>
+      <div class="drop-item" style="margin-top: 12px;" *ngIf="selectedType.value === 'poi' && selectedIconType.value !== 'POI水滴'">
+        <span>Icon</span>
+        <div>
+          <app-dropdown [options]="iconOptions1" [(ngModel)]="selectedIcon"></app-dropdown>
+        </div>
+      </div>
+      <div class="drop-item" style="margin-top: 12px;" *ngIf="selectedType.value === 'poi' && selectedIconType.value === 'POI水滴'">
+        <span>Icon</span>
+        <div>
+          <app-dropdown [options]="iconOptions2" [(ngModel)]="selectedIcon"></app-dropdown>
         </div>
       </div>
       <div class="input-item">

--- a/src/app/pages/overlay/overlay.component.ts
+++ b/src/app/pages/overlay/overlay.component.ts
@@ -1,13 +1,6 @@
 import { Component, OnInit, Renderer2 } from '@angular/core';
-import {
-  Emissive,
-  Marker,
-  Model,
-  POI,
-  POIIcon,
-  Quaternion,
-  Vector3,
-} from '@sheencity/diva-sdk';
+import { Emissive, Marker, Model, POI, POIIcon } from '@sheencity/diva-sdk';
+import { Euler, Quaternion, Vector3, deg2rad } from '@sheencity/diva-sdk-math';
 import { DropdownData } from 'src/app/common/models/dropdown-data.interface';
 import { DataService } from 'src/app/common/services/data.service';
 import { DivaService } from 'src/app/common/services/diva.service';
@@ -90,10 +83,10 @@ export class OverlayComponent implements OnInit {
     { value: POIIcon.Supermarket, placeholder: '超市' },
     { value: POIIcon.Mall, placeholder: '商场' },
     { value: POIIcon.Toilet, placeholder: '卫生间' },
-    { value: POIIcon.Building, placeholder: '建筑'},
-    { value: POIIcon.ChargingPile, placeholder: '充电桩'},
-    { value: POIIcon.EnergyStorage, placeholder: '储能设备'},
-    { value: POIIcon.SolarEnergy, placeholder: '光伏'},
+    { value: POIIcon.Building, placeholder: '建筑' },
+    { value: POIIcon.ChargingPile, placeholder: '充电桩' },
+    { value: POIIcon.EnergyStorage, placeholder: '储能设备' },
+    { value: POIIcon.SolarEnergy, placeholder: '光伏' },
   ];
   iconOptions2 = [
     ...this.iconOptions1,
@@ -143,7 +136,7 @@ export class OverlayComponent implements OnInit {
         title: overlay.content,
         backgroundColor: overlay.color,
         opacity: overlay.opacity,
-        scale: overlay.scale,
+        scale: new Vector3(overlay.scale, overlay.scale, overlay.scale),
         coord: new Vector3(
           overlay.coordinateX,
           overlay.coordinateY,
@@ -185,7 +178,7 @@ export class OverlayComponent implements OnInit {
         },
         backgroundColor: overlay.color,
         opacity: overlay.opacity,
-        scale: overlay.scale,
+        scale: new Vector3(overlay.scale, overlay.scale, overlay.scale),
         coord: new Vector3(
           overlay.coordinateX,
           overlay.coordinateY,
@@ -226,10 +219,14 @@ export class OverlayComponent implements OnInit {
           overlay.coordinateY,
           overlay.coordinateZ
         ),
-        rotation: Quaternion.FromEulerAngles(
-          (overlay.rotationX * Math.PI) / 180,
-          (overlay.rotationY * Math.PI) / 180,
-          (overlay.rotationZ * Math.PI) / 180
+        rotation: Quaternion.FromEuler(
+          new Euler(
+            ...deg2rad([
+              overlay.rotationX,
+              overlay.rotationY,
+              overlay.rotationZ,
+            ])
+          )
         ),
         scale: new Vector3(overlay.scale, overlay.scale, overlay.scale),
         resource: {
@@ -310,7 +307,7 @@ export class OverlayComponent implements OnInit {
    */
   async pickup() {
     const handler = (event: DivaMouseEvent) => {
-      const wordPosition = event.worldPosition;
+      const wordPosition = event.detail.coord;
       this.coordinateX = wordPosition.x;
       this.coordinateY = wordPosition.y;
       this.coordinateZ = wordPosition.z;

--- a/src/app/pages/overlay/overlay.component.ts
+++ b/src/app/pages/overlay/overlay.component.ts
@@ -136,6 +136,7 @@ export class OverlayComponent implements OnInit {
         title: overlay.content,
         backgroundColor: overlay.color,
         opacity: overlay.opacity,
+        autoSize: false,
         scale: new Vector3(overlay.scale, overlay.scale, overlay.scale),
         coord: new Vector3(
           overlay.coordinateX,
@@ -146,7 +147,7 @@ export class OverlayComponent implements OnInit {
           name: overlay.iconType,
         },
         id: overlay.id,
-        name: overlay.content,
+        name: this._uniqueName('poi'),
       });
       await poiOverlay.setClient(this._diva.client);
       poiOverlay.focus(1000, -Math.PI / 6);
@@ -178,6 +179,7 @@ export class OverlayComponent implements OnInit {
         },
         backgroundColor: overlay.color,
         opacity: overlay.opacity,
+        autoSize: false,
         scale: new Vector3(overlay.scale, overlay.scale, overlay.scale),
         coord: new Vector3(
           overlay.coordinateX,
@@ -188,7 +190,7 @@ export class OverlayComponent implements OnInit {
           name: '文字标签',
         },
         id: overlay.id,
-        name: overlay.title,
+        name: this._uniqueName('marker'),
       });
       await markerOverlay.setClient(this._diva.client);
       markerOverlay.focus(1000, -Math.PI / 6);
@@ -233,7 +235,7 @@ export class OverlayComponent implements OnInit {
           name: overlay.icon,
         },
         id: overlay.id,
-        name: overlay.icon,
+        name: this._uniqueName('effect'),
       });
       await emissiveOverlay.setClient(this._diva.client);
       emissiveOverlay.focus(1000, -Math.PI / 6);
@@ -245,6 +247,10 @@ export class OverlayComponent implements OnInit {
     }
     this.overlays = this._store.getAllOverlays();
     this.reset();
+  }
+
+  private _uniqueName(prefix: string) {
+    return '' + prefix + '_' + new Date().toISOString();
   }
 
   /**

--- a/src/app/pages/overlay/overlay.component.ts
+++ b/src/app/pages/overlay/overlay.component.ts
@@ -4,6 +4,7 @@ import {
   Marker,
   Model,
   POI,
+  POIIcon,
   Quaternion,
   Vector3,
 } from '@sheencity/diva-sdk';
@@ -16,8 +17,8 @@ import {
   EmissiveOverlay,
   MarkerOverlay,
   OverlayType,
-  POIIcon,
   POIOverlay,
+  POIType,
 } from 'src/app/common/models/overlay.model';
 import { DivaMouseEvent } from '@sheencity/diva-sdk/lib/events/diva.events';
 @Component({
@@ -27,17 +28,25 @@ import { DivaMouseEvent } from '@sheencity/diva-sdk/lib/events/diva.events';
 })
 export class OverlayComponent implements OnInit {
   public overlays: (POIOverlay | MarkerOverlay | EmissiveOverlay)[] = [];
-  public selectedType: DropdownData = {
+  public selectedType: DropdownData<OverlayType> = {
     value: OverlayType.POI,
     placeholder: 'POI',
   };
-  public selectedIcon: DropdownData = {
+  public selectedIcon: DropdownData<POIIcon> = {
     value: POIIcon.Camera,
     placeholder: '摄像头',
+  };
+  public selectedIconType: DropdownData<POIType> = {
+    value: POIType.type1,
+    placeholder: 'POI文字标签',
   };
   public selectedEmissive: DropdownData<EmissionType> = {
     value: EmissionType.type1,
     placeholder: '悬浮标记01',
+  };
+  public selectedAlign: DropdownData<'center' | 'left' | 'right'> = {
+    value: 'center',
+    placeholder: '居中',
   };
   public coordinateX = 0.0;
   public coordinateY = 0.0;
@@ -55,25 +64,18 @@ export class OverlayComponent implements OnInit {
   public selectedId: string = null;
   public emission: number = 1.0;
   public speed: number = 2.0;
-  public selectedAlign = {
-    value: 'center',
-    placeholder: '居中',
-  } as {
-    value: 'left' | 'right' | 'center';
-    placeholder: string;
-  };
 
   typeOptions = [
     { value: OverlayType.POI, placeholder: 'POI' },
     { value: OverlayType.Marker, placeholder: 'Marker' },
     { value: OverlayType.Emissive, placeholder: 'Effect' },
   ];
-  alignOptions = [
+  alignOptions: Array<DropdownData<'center' | 'left' | 'right'>> = [
     { value: 'center', placeholder: '居中' },
     { value: 'left', placeholder: '左对齐' },
     { value: 'right', placeholder: '右对齐' },
   ];
-  iconOptions = [
+  iconOptions1 = [
     { value: POIIcon.Camera, placeholder: '摄像头' },
     { value: POIIcon.Location, placeholder: '定位' },
     { value: POIIcon.TrafficLight, placeholder: '红路灯' },
@@ -88,6 +90,20 @@ export class OverlayComponent implements OnInit {
     { value: POIIcon.Supermarket, placeholder: '超市' },
     { value: POIIcon.Mall, placeholder: '商场' },
     { value: POIIcon.Toilet, placeholder: '卫生间' },
+    { value: POIIcon.Building, placeholder: '建筑'},
+    { value: POIIcon.ChargingPile, placeholder: '充电桩'},
+    { value: POIIcon.EnergyStorage, placeholder: '储能设备'},
+    { value: POIIcon.SolarEnergy, placeholder: '光伏'},
+  ];
+  iconOptions2 = [
+    ...this.iconOptions1,
+    { value: POIIcon.CO, placeholder: '一氧化碳' },
+    { value: POIIcon.Seat, placeholder: '座椅' },
+  ];
+  iconTypeOption = [
+    { value: POIType.type1, placeholder: 'POI文字标签' },
+    { value: POIType.type2, placeholder: 'POI圆形标签' },
+    { value: POIType.type3, placeholder: 'POI水滴' },
   ];
   emissiveOptions = [
     { value: EmissionType.type1, placeholder: '悬浮标记01' },
@@ -113,7 +129,8 @@ export class OverlayComponent implements OnInit {
   async create() {
     if (this.selectedType.value === OverlayType.POI) {
       const overlay = new POIOverlay();
-      overlay.icon = this.selectedIcon.value as POIIcon;
+      overlay.iconType = this.selectedIconType.value;
+      overlay.icon = this.selectedIcon.value;
       overlay.coordinateX = this.coordinateX;
       overlay.coordinateY = this.coordinateY;
       overlay.coordinateZ = this.coordinateZ;
@@ -133,7 +150,7 @@ export class OverlayComponent implements OnInit {
           overlay.coordinateZ
         ),
         resource: {
-          name: 'POI文字标签',
+          name: overlay.iconType,
         },
         id: overlay.id,
         name: overlay.content,
@@ -248,22 +265,21 @@ export class OverlayComponent implements OnInit {
     this._data.changeCode(`entity.setClient(null)`);
   }
 
+  resetPoiIcon(v: DropdownData<POIType>) {
+    let iconOption: Array<DropdownData<POIIcon>>;
+    iconOption =
+      v.value == POIType.type3 ? this.iconOptions2 : this.iconOptions1;
+    if (iconOption.find((x) => x.value === this.selectedIcon.value)) return;
+    this.selectedIcon = iconOption[0];
+  }
   /**
    * 创建覆盖物之后重置所有配置
    */
   reset() {
-    this.selectedIcon = {
-      value: POIIcon.Camera,
-      placeholder: '摄像头',
-    };
-    this.selectedEmissive = {
-      value: EmissionType.type1,
-      placeholder: '悬浮标记01',
-    };
-    this.selectedAlign = {
-      value: 'center',
-      placeholder: '居中',
-    };
+    this.selectedIconType = this.iconTypeOption[0];
+    this.selectedIcon = this.iconOptions1[0];
+    this.selectedEmissive = this.emissiveOptions[0];
+    this.selectedAlign = this.alignOptions[0];
     this.coordinateX = 0.0;
     this.coordinateY = 0.0;
     this.coordinateZ = 0.0;

--- a/src/app/pages/state/state.component.html
+++ b/src/app/pages/state/state.component.html
@@ -1,13 +1,13 @@
 <main>
-    <app-content-block caption="设备状态">
-        <ng-container *ngFor="let equipment of equipments; index as i">
-            <div class="drop-block">
-                <div class="drop-item" [class.selected]="selected === i">
-                    <span>{{equipment.title}}</span>
-                    <app-dropdown (select)="onChange(equipment, $event)" [options]="options"
-                        [(ngModel)]="equipment.selected"></app-dropdown>
-                </div>
-            </div>
-        </ng-container>
-    </app-content-block>
+  <app-content-block caption="设备状态">
+    <ng-container *ngFor="let equipment of equipments; index as i">
+      <div class="drop-block">
+        <div class="drop-item">
+          <span>{{equipment.title}}</span>
+          <app-dropdown (select)="onChange(equipment, $event)" [options]="options" [(ngModel)]="equipment.selected">
+          </app-dropdown>
+        </div>
+      </div>
+    </ng-container>
+  </app-content-block>
 </main>

--- a/src/app/pages/state/state.component.ts
+++ b/src/app/pages/state/state.component.ts
@@ -5,23 +5,19 @@ import { DataService } from 'src/app/common/services/data.service';
 import { DivaService } from 'src/app/common/services/diva.service';
 
 const equipments = [
-  {
-    title: '空调',
-    state: RenderingStyleMode.Default,
-  },
-  {
-    title: '电视机',
-    state: RenderingStyleMode.Default,
-  },
-  {
-    title: '路由器',
-    state: RenderingStyleMode.Default,
-  },
-  {
-    title: '冰箱',
-    state: RenderingStyleMode.Default,
-  },
+  { title: '空调', state: RenderingStyleMode.Default },
+  { title: '电视机', state: RenderingStyleMode.Default },
+  { title: '路由器', state: RenderingStyleMode.Default },
+  { title: '冰箱', state: RenderingStyleMode.Default },
 ] as { title: string; state: RenderingStyleMode }[];
+
+type HighlightStyleOpt = {
+  color?: string;
+  border?: {
+    color?: string;
+    width?: number;
+  };
+};
 
 @Component({
   selector: 'app-state',
@@ -29,20 +25,20 @@ const equipments = [
   styleUrls: ['./state.component.scss'],
 })
 export class StateComponent implements OnInit, OnDestroy {
-  // 选中的设备
-  selectedEqui: any = null;
-  // 选中的设备的 index 值，为了添加选中文字变白，暂时未使用
-  selected: number = null;
+  highlightStyle: HighlightStyleOpt;
+
   equipments = equipments.map((equipment) => this.addSelected(equipment));
-  constructor(private _diva: DivaService, private _data: DataService) {}
 
   // 状态配置
   options = [
     { value: RenderingStyleMode.Default, placeholder: '默认' },
     { value: RenderingStyleMode.Alarm, placeholder: '报警' },
     { value: RenderingStyleMode.Translucence, placeholder: '半透' },
-    { value: RenderingStyleMode.Hidden, placeholder: '隐藏' },
+    { value: RenderingStyleMode.Highlight, placeholder: '高亮' },
+    { value: RenderingStyleMode.Emission, placeholder: '自发光' },
   ] as DropdownData<RenderingStyleMode>[];
+
+  constructor(private _diva: DivaService, private _data: DataService) {}
 
   /**
    * 设备添加 selected 属性，方便在循环下拉框组件中绑定值
@@ -59,10 +55,19 @@ export class StateComponent implements OnInit, OnDestroy {
         selected = { value: RenderingStyleMode.Alarm, placeholder: '报警' };
         break;
       case RenderingStyleMode.Translucence:
-        selected = { value: RenderingStyleMode.Translucence, placeholder: '半透' };
+        selected = {
+          value: RenderingStyleMode.Translucence,
+          placeholder: '半透',
+        };
         break;
-      case RenderingStyleMode.Hidden:
-        selected = { value: RenderingStyleMode.Hidden, placeholder: '隐藏' };
+      case RenderingStyleMode.Highlight:
+        selected = { value: RenderingStyleMode.Highlight, placeholder: '高亮' };
+        break;
+      case RenderingStyleMode.Emission:
+        selected = {
+          value: RenderingStyleMode.Emission,
+          placeholder: '自发光',
+        };
         break;
       default:
         selected = { value: RenderingStyleMode.Default, placeholder: '默认' };
@@ -84,27 +89,56 @@ export class StateComponent implements OnInit, OnDestroy {
     const [model] = await this._diva.client.getEntitiesByName<Model>(
       equi.title
     );
-    if (!model) return;
-    const type = $event.value as RenderingStyleMode;
-    model.setRenderingStyleMode(type);
-
-    this._data.changeCode(
-      `model.setRenderingStyleMode(RenderingStyleMode.${
-        type.slice(0, 1).toUpperCase() + type.slice(1)
-      })`
-    );
+    if (!model || !$event.value) return;
+    type renderMode =
+      | RenderingStyleMode.Default
+      | RenderingStyleMode.Alarm
+      | RenderingStyleMode.Translucence
+      | RenderingStyleMode.Highlight
+      | RenderingStyleMode.Emission;
+    const type = $event.value as renderMode;
+    let code = `model.setRenderingStyleMode(RenderingStyleMode.${
+      type.slice(0, 1).toUpperCase() + type.slice(1)
+    }`;
+    if (type == RenderingStyleMode.Emission) {
+      model.setRenderingStyleMode(type, {
+        color: '#20fdfa99',
+        strength: 0.2,
+      });
+      code += `, { color: '#20fdfa99', strength: 0.2 })`;
+    } else {
+      model.setRenderingStyleMode(type);
+      code += `)`;
+    }
+    this._data.changeCode(code);
   }
 
-  ngOnInit(): void {
+  private async _setHighlightStyle(opt: HighlightStyleOpt) {
+    if (JSON.stringify(this.highlightStyle) === JSON.stringify(opt)) return;
+    await this._diva.client.setHighlightStyle(opt);
+    this.highlightStyle = opt;
+  }
+
+  async ngOnInit(): Promise<void> {
     this._diva.client?.applyScene('状态演示').then(() => {
       this._data.changeCode(`client.applyScene('状态演示')`);
     });
+    const highlightStyleOpt = {
+      color: '#20fdfa99',
+      border: {
+        color: '#20fdfa',
+        width: 2,
+      },
+    } as HighlightStyleOpt;
+    await this._setHighlightStyle(highlightStyleOpt);
   }
 
   // 销毁钩子
   ngOnDestroy(): void {
     this.equipments.forEach(async (equi) => {
-      const [model] = await this._diva.client.getEntitiesByName<Model>(equi.title);
+      const [model] = await this._diva.client.getEntitiesByName<Model>(
+        equi.title
+      );
       model.setRenderingStyleMode(RenderingStyleMode.Default);
     });
   }

--- a/src/app/pages/video/video.component.ts
+++ b/src/app/pages/video/video.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { DataService } from 'src/app/common/services/data.service';
 import { DivaService } from 'src/app/common/services/diva.service';
 
@@ -20,7 +20,7 @@ const videos = [
   templateUrl: './video.component.html',
   styleUrls: ['./video.component.scss'],
 })
-export class VideoComponent implements OnInit {
+export class VideoComponent implements OnInit, OnDestroy {
   public videos = videos;
 
   public selectedVideo: string = null;
@@ -42,5 +42,9 @@ export class VideoComponent implements OnInit {
     this._diva.client?.applyScene('半鸟瞰').then(() => {
       this._data.changeCode(`client.applyScene('半鸟瞰')`);
     });
+  }
+
+  ngOnDestroy(): void {
+    this._diva.client.stopCameraTrack();
   }
 }


### PR DESCRIPTION
1. 升级diva-sdk至0.2.1版本，修改创建diva对象的方式及其他代码格式。
2. 覆盖物演示页中，POI标签的创建方式增加一个type属性，用于指定POI标签的类型；创建各类覆盖物的name参数改为唯一值。
3. 状态演示页中，增加模型的高光、自发光两种渲染模式，删除隐藏这种渲染模式。